### PR TITLE
Update PATH for avm

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -135,6 +135,13 @@ install_anchor_cli() {
         cargo install --git https://github.com/coral-xyz/anchor avm
         avm install latest
         avm use latest
+
+        if [[ "$os" == "Linux" ]]; then
+            export PATH="$HOME/.avm/bin:$PATH"
+        elif [[ "$os" == "Darwin" ]]; then
+            echo 'export PATH="$HOME/.avm/bin:$PATH"' >> ~/.zshrc
+        fi
+
         log_info "Anchor CLI installation complete."
     fi
 


### PR DESCRIPTION
### Bug Report

**Describe the bug**

The installation script successfully installs the Anchor Version Manager (`avm`) and uses it to install the `anchor` CLI. However, it fails to update the `PATH` environment variable within the same script's execution session. As a result, the final verification step (`command -v anchor`) cannot find the newly installed `anchor` binary, leading to a misleading error message: `[ERROR] Anchor CLI installation failed.` The installation itself is actually successful.

**To Reproduce**

1.  Start with a clean environment where `anchor` and `avm` are not installed (e.g., a fresh Docker container or VM).
2.  Run the installation script containing the `install_anchor_cli` function.
3.  Observe the output logs.

**Expected Behavior**

The script should complete the installation and the final check should succeed, printing the installed Anchor version and a success message.

```
[INFO] Anchor CLI installation complete.
anchor-cli 0.31.1
```

**Actual Behavior**

The script successfully installs `avm` and `anchor`, but the final check fails, resulting in a confusing output sequence:

```
... (successful installation logs) ...
Now using anchor version 0.31.1.
[INFO] Anchor CLI installation complete.
[ERROR] Anchor CLI installation failed.
```

The script reports success and failure almost simultaneously because the `anchor` command is not found in the current session's `PATH`.

### Root Cause and Solution

The `avm` tool installs binaries into `$HOME/.avm/bin`, as noted in its own warning message:
`warning: be sure to add /home/vscode/.avm/bin to your PATH...`

The installation script does not update the `PATH` for its current execution environment. Therefore, when `command -v anchor` is called, the shell doesn't know where to find the executable.

**Suggested Fix**

The `PATH` variable should be explicitly exported after `avm` has been used to set the anchor version. This makes the `anchor` binary immediately available for the verification step.

Add `export PATH="$HOME/.avm/bin:$PATH"` to the `install_anchor_cli` function.

This small change ensures the script's behavior is consistent and correctly reports a successful installation.

Fix has been tested with Ubuntu 24.04.