### PR TITLE
temp fix node install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -174,23 +174,40 @@ install_nvm_and_node() {
         . "$NVM_DIR/bash_completion"
     fi
 
+    # Temporary hardcode Node.js version 24.9.0 due to https://github.com/nodejs/node/issues/60176
+    # Original code - checking for latest version
+    # if command -v node >/dev/null 2>&1; then
+    #     local current_node
+    #     current_node=$(node --version)
+    #     local latest_node
+    #     latest_node=$(nvm version-remote node)
+    #     if [ "$current_node" = "$latest_node" ]; then
+    #         log_info "Latest Node.js ($current_node) is already installed."
+    #     else
+    #         log_info "Updating Node.js: Installed ($current_node), Latest ($latest_node)."
+    #         nvm install node
+    #         nvm alias default node
+    #         nvm use default
+    #     fi
+    # else
+
+    # Install specific Node.js version 24.9.0
     if command -v node >/dev/null 2>&1; then
         local current_node
         current_node=$(node --version)
-        local latest_node
-        latest_node=$(nvm version-remote node)
-        if [ "$current_node" = "$latest_node" ]; then
-            log_info "Latest Node.js ($current_node) is already installed."
+        local target_node="v24.9.0"
+        if [ "$current_node" = "$target_node" ]; then
+            log_info "Node.js 24.9.0 is already installed."
         else
-            log_info "Updating Node.js: Installed ($current_node), Latest ($latest_node)."
-            nvm install node
-            nvm alias default node
+            log_info "Installing Node.js 24.9.0: Currently installed ($current_node)."
+            nvm install 24.9.0
+            nvm alias default 24.9.0
             nvm use default
         fi
     else
-        log_info "Installing Node.js via NVM..."
-        nvm install node
-        nvm alias default node
+        log_info "Installing Node.js 24.9.0 via NVM..."
+        nvm install 24.9.0
+        nvm alias default 24.9.0
         nvm use default
     fi
 


### PR DESCRIPTION
 - latest node versions is v24.10.0, but missing [darwin files](https://nodejs.org/dist/v24.10.0/)
 - results in error when installing on mac
 ```
 Downloading and installing node v24.10.0...
Downloading https://nodejs.org/dist/v24.10.0/node-v24.10.0-darwin-arm64.tar.xz...
curl: (56) The requested URL returned error: 404                               

download from https://nodejs.org/dist/v24.10.0/node-v24.10.0-darwin-arm64.tar.xz failed
grep: /Users/johnliu/.nvm/.cache/bin/node-v24.10.0-darwin-arm64/node-v24.10.0-darwin-arm64.tar.xz: No such file or directory
Provided file to checksum does not exist.
```
- temp fix to hardcode node v24.9.0
 - https://github.com/nodejs/node/issues/60176