### PR TITLE
Feat/install solana dev skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ To install the following dependencies for local development:
 - Rust
 - Node.js
 - Yarn
+- Solana dev skill for AI coding agents (Claude Code, Codex, Cursor, etc.)
 
 Output upon successful installation should be similar to the following:
 

--- a/install.sh
+++ b/install.sh
@@ -377,6 +377,25 @@ install_surfpool() {
 }
 
 ########################################
+# Install Solana Dev Skill for AI Agents
+########################################
+install_solana_dev_skill() {
+    if ! command -v npx >/dev/null 2>&1; then
+        log_info "npx not found, skipping Solana dev skill installation."
+        return 0
+    fi
+
+    log_info "Installing Solana dev skill for AI coding agents..."
+    if npx -y skills add https://github.com/solana-foundation/solana-dev-skill --all -y; then
+        log_info "Solana dev skill installation complete."
+    else
+        log_info "Solana dev skill installation skipped (non-fatal)."
+    fi
+
+    echo ""
+}
+
+########################################
 # Print Installed Versions
 ########################################
 print_versions() {
@@ -434,6 +453,7 @@ main() {
     install_nvm_and_node || log_error "Failed to install NVM/Node.js."
     install_yarn || log_error "Failed to install Yarn."
     install_surfpool || log_error "Failed to install Surfpool."
+    install_solana_dev_skill || log_error "Failed to install Solana dev skill."
 
     ensure_nvm_in_shell
 

--- a/install.sh
+++ b/install.sh
@@ -386,7 +386,7 @@ install_solana_dev_skill() {
     fi
 
     log_info "Installing Solana dev skill for AI coding agents..."
-    if npx -y skills add https://github.com/solana-foundation/solana-dev-skill --all -y; then
+    if npx -y skills add https://github.com/solana-foundation/solana-dev-skill --all -y -g; then
         log_info "Solana dev skill installation complete."
     else
         log_info "Solana dev skill installation skipped (non-fatal)."

--- a/install.sh
+++ b/install.sh
@@ -386,7 +386,7 @@ install_solana_dev_skill() {
     fi
 
     log_info "Installing Solana dev skill for AI coding agents..."
-    if npx -y skills add https://github.com/solana-foundation/solana-dev-skill --all -y -g; then
+    if npx -y skills add https://github.com/solana-foundation/solana-dev-skill --skill '*' -y -g; then
         log_info "Solana dev skill installation complete."
     else
         log_info "Solana dev skill installation skipped (non-fatal)."


### PR DESCRIPTION
Runs `npx skills add` after toolchain setup to install the [solana-dev-skill](https://github.com/solana-foundation/solana-dev-skill) for all supported AI agents (Claude Code, Codex, Cursor, etc.). Non-fatal if it fails.